### PR TITLE
Inject scriptcode only for html format

### DIFF
--- a/_extensions/critic-markup/critic-markup.lua
+++ b/_extensions/critic-markup/critic-markup.lua
@@ -161,13 +161,15 @@ end
 
 
 function criticheader (meta)
-  quarto.doc.add_html_dependency({
-    name = 'critic',
-    scripts = {'critic.min.js'},
-    stylesheets = {'critic.css'}
-  })
-  -- inject the rendering code
-  quarto.doc.include_text("after-body", scriptcode)
+  if FORMAT:match 'html' then
+    quarto.doc.add_html_dependency({
+      name = 'critic',
+      scripts = {'critic.min.js'},
+      stylesheets = {'critic.css'}
+    })
+    -- inject the rendering code
+    quarto.doc.include_text("after-body", scriptcode)
+  end
 end
 
 -- All pass with Meta first


### PR DESCRIPTION
The critic-markup breaks PDF creation according to the following Latex error:
```
ERROR: 
compilation failed- error
You can't use `macro parameter character #' in horizontal mode.
l.205       $('#
                markup-button').addClass('active'); 
```

This MR does not inject the javascript code into the Latex.

Getting critic-markup to work properly on a PDF is outside of my scope now, but I think getting it to at least not break PDF output is good.