### PR TITLE
Add support for seeing original, markup, and edited versions for HTML and PDF

### DIFF
--- a/_extensions/critic-markup/critic-markup.lua
+++ b/_extensions/critic-markup/critic-markup.lua
@@ -2,7 +2,7 @@
 local maybesubs = false
 local stk_end = false
 
-if FORMAT:match 'html' then
+if quarto.doc.is_format('html') then
   add = pandoc.RawInline('html', "<ins>")
   adde = pandoc.RawInline('html', "</ins>")
 
@@ -15,7 +15,7 @@ if FORMAT:match 'html' then
 
   comm = pandoc.RawInline('html', [[<span class="critic comment">]])
   comme = pandoc.RawInline('html', "</span>")
-elseif FORMAT:match 'latex' then
+elseif quarto.doc.is_format('latex') then
   add = pandoc.RawInline('latex', "\\criticmarkupadd{")
   adde = pandoc.RawInline('latex', "}")
 
@@ -28,16 +28,23 @@ elseif FORMAT:match 'latex' then
 
   comm = pandoc.RawInline('latex', "\\criticmarkupcomm{")
   comme = pandoc.RawInline('latex', "}")
+else
+  unsupported = true
+  adde = pandoc.Str("++}")
+  rm = pandoc.Str("{--")
 end
-ruless = {['{%+%+']=add, ['{\u{2013}']=rm, ['{==']=mark, ['{>>']=comm, ['{~~']=rm,
-          ['%+%+}']=adde, ['\u{2013}}']=rme, ['==}']=marke, ['<<}']=comme, ['~~}']=rme, ['~>']=rmeadd}
+if unsupported then
+  ruless = {}
+else
+  ruless = {['{%+%+']=add, ['{\u{2013}']=rm, ['{==']=mark, ['{>>']=comm, ['{~~']=rm,
+            ['%+%+}']=adde, ['\u{2013}}']=rme, ['==}']=marke, ['<<}']=comme, ['~~}']=rme, ['~>']=rmeadd}
+end
 
 -- Strikeout before/after
 st_b = '{'
 st_e = '}'
 
 local scriptcode = [[
-
 <div id="criticnav">
 <ul>
 <li id="markup-button">Markup</li>
@@ -90,7 +97,7 @@ local scriptcode = [[
   var e = document.getElementById("edited-button");
   var m = document.getElementById("markup-button");
 
-  window.onload = critic();
+  window.addEventListener('load', critic)
   o.onclick = original;
   e.onclick = edited;
   m.onclick = markup;
@@ -112,6 +119,49 @@ local latexcode = [[
   \newcommand{\criticmarkupmark}[1]{\{=={##1}==\}}
   \newcommand{\criticmarkupcomm}[1]{\{>{}>{##1}<{}<\}}
 }
+\IfFileExists{draftwatermark.sty}
+{
+  \usepackage{draftwatermark}
+  \DraftwatermarkOptions{%
+    pos={5mm,5mm},
+    anchor=lt,
+    alignment=l,
+    fontsize=10mm,
+    angle=0
+  }
+  \DraftwatermarkOptions{text=Markup}
+}
+
+\newcounter{criticmarkupfirstpage}
+
+]]
+
+local latexcode_edited = [[
+  \renewcommand{\criticmarkupadd}[1]{#1}
+  \renewcommand{\criticmarkuprm}[1]{}
+  \renewcommand{\criticmarkupmark}[1]{#1}
+  \renewcommand{\criticmarkupcomm}[1]{}
+  \IfFileExists{draftwatermark.sty}
+  {
+    \DraftwatermarkOptions{text=Edited}
+  }
+]]
+
+local latexcode_original = [[
+  \renewcommand{\criticmarkupadd}[1]{}
+  \renewcommand{\criticmarkuprm}[1]{#1}
+  \renewcommand{\criticmarkupmark}[1]{#1}
+  \renewcommand{\criticmarkupcomm}[1]{}
+  \IfFileExists{draftwatermark.sty}
+  {
+    \DraftwatermarkOptions{text=Original}
+  }
+]]
+
+local latexcode_reset = [[
+\maketitle
+
+\setcounter{page}{\value{criticmarkupfirstpage}}
 ]]
 
 function cirtiblock(blocks, k, v)
@@ -189,18 +239,61 @@ end
 
 
 function criticheader (meta)
-  if FORMAT:match 'html' then
+  local version = meta["critic-markup-version"]
+  CRITIC_VERSION = version and pandoc.utils.stringify(version) or "all"
+  local valid_versions = {all=true, markup=true, edited=true, original=true}
+  if not valid_versions[CRITIC_VERSION] then
+    error("Invalid critic-markup-version: " .. CRITIC_VERSION)
+  end
+  if quarto.doc.is_format('html') then
     quarto.doc.add_html_dependency({
       name = 'critic',
       scripts = {'critic.min.js'},
       stylesheets = {'critic.css'}
     })
     -- inject the rendering code
-    quarto.doc.include_text("after-body", scriptcode)
-  else
+    quarto.doc.include_text("in-header", scriptcode)
+    if CRITIC_VERSION == "all" then
+      return
+    end
+    local activate = [[
+      <script>
+        document.getElementById("criticnav").style.display = "none";
+        window.addEventListener('load', CRITIC_VERSION)
+      </script>
+    ]]
+    activate = activate:gsub("CRITIC_VERSION", CRITIC_VERSION)
+    quarto.doc.include_text("in-header", activate)
+  elseif quarto.doc.is_format('latex') then
     quarto.doc.include_text("in-header", latexcode)
+    quarto.doc.include_text("before-body", "\\setcounter{criticmarkupfirstpage}{\\value{page}}")
+  end
+end
+
+if quarto.doc.is_format('latex') then
+  function Pandoc(doc)
+    local n = #doc.blocks
+
+    if CRITIC_VERSION == "all" then
+      -- Insert edited version of document.
+      table.insert(doc.blocks, pandoc.RawInline('latex', latexcode_edited .. latexcode_reset))
+      for i = 0,n-1 do
+        table.insert(doc.blocks, doc.blocks[i])
+      end
+
+      -- Insert original version of document.
+      table.insert(doc.blocks, pandoc.RawInline('latex', latexcode_original .. latexcode_reset))
+      for i = 0,n-1 do
+        table.insert(doc.blocks, doc.blocks[i])
+      end
+    elseif CRITIC_VERSION == "edited" then
+      quarto.doc.include_text("in-header", latexcode_edited)
+    elseif CRITIC_VERSION == "original" then
+      quarto.doc.include_text("in-header", latexcode_original)
+    end
+    return doc
   end
 end
 
 -- All pass with Meta first
-return {{Meta = criticheader}, {Inlines = Inlines}, {Strikeout = Strikeout}, {Str = Str}}
+return {{Meta = criticheader}, {Inlines = Inlines}, {Strikeout = Strikeout}, {Str = Str}, {Pandoc = Pandoc}}

--- a/_extensions/critic-markup/critic.css
+++ b/_extensions/critic-markup/critic.css
@@ -1,4 +1,4 @@
-.fullcontent {
+#quarto-content {
     padding-top: 30px !important;
 }
 

--- a/example-multiformat.qmd
+++ b/example-multiformat.qmd
@@ -1,0 +1,65 @@
+---
+title: "Critic-markdown multi-format example"
+format:
+  html: default
+  html+markup:
+    output-file: example-multiformat+markup.html
+  html+edited:
+    output-file: example-multiformat+edited.html
+  html+original:
+    output-file: example-multiformat+original.html
+  pdf: default
+  pdf+markup: default
+  pdf+edited: default
+  pdf+original: default
+filters:
+  - critic-markup
+format-links:
+  - text: HTML
+    href: ./example-multiformat.html
+  - text: HTML+markup
+    href: ./example-multiformat+markup.html
+  - text: HTML+edited
+    href: ./example-multiformat+edited.html
+  - text: HTML+original
+    href: ./example-multiformat+original.html
+  - pdf
+  - format: pdf+edited
+    text: PDF+edited
+  - format: pdf+original
+    text: PDF+original
+  - format: pdf+markup
+    text: PDF+markup
+
+---
+
+
+## Critic Markdown
+
+This filter adds processing of critic markdown syntax. Below are examples of usage.
+
+## Highlighting
+
+`{==Highlighted text==}` {==Highlighted text==}
+
+`{== Highlighted text with a comment==}{>>First comment<<}` {== Highlighted text with a comment==}{>>First comment<<}
+
+`{>>Single comment <<}` {>>Single comment <<}
+
+
+## Addition
+
+`{++This is added text++}` {++This is added text++}
+
+`{++This is added text with some removed++}{-- removed--}` {++This is added text with some removed++}{-- removed--}
+
+
+## Deletion
+
+`{--This is removed text--}` {--This is removed text--}
+
+`{--This is removed text with some added--}{++added ++}` {--This is removed text with some added--}{++added ++}
+
+## Replacement
+
+`{~~This is original text~> this is the replacement~~}` {~~This is original text~> this is the replacement~~}


### PR DESCRIPTION
This PR adds a meta variable `critic-markup-version` that can specify the output format. It can be "all", "markup", "edited", or "original". It's default value of "all"  does the normal thing of showing all three formats.

This format option is especially useful for looking at the edited or original form of the PDF, which previously, only supported the "markup" output.

Unfortunately, outputting multiple versions with the same file extension is difficult with Quarto.

- For HTML, the output file for each format needs to be defined to avoid overwriting the other formats' output.
- For PDF, defining the output file does not affect the intermediate latex file that is created. Instead, the pandoc modifier (adding "+something" after the Quarto format name) must be used, but the output file doesn't need to be defined. (This doesn't work for HTML).

Since the pandoc modifier has to be used for PDF, I simplified the syntax to allow the `critic-markup-version` variable to be read from the output file name. So if the modifier is a valid `critic-markup-version` value, it is read as the default instead of using "all" as the default.

Here's is an example of what the pdf format looks like for each version:

<img src="https://github.com/user-attachments/assets/1fdd1c61-391f-4c4d-897a-e6eaf7a43d2f"  height="200">
<img src="https://github.com/user-attachments/assets/1fb013e0-6ba1-41db-ba98-dab1879faa04"  height="200">
<img src="https://github.com/user-attachments/assets/d95cbf60-c8cd-4b07-8ba9-92c57af1d2b4"  height="200">

This PR also essentially disables the filter for Quarto output formats other than HTML, PDF, and Latex, thereby fixing a bug that caused the filter to break other Quarto output formats.

@mloubout I'd like to get your opinion on these changes before I update the documentation and mark this PR as ready.